### PR TITLE
Fix MIMEText compatibility.

### DIFF
--- a/collective/MockMailHost/MockMailHost.py
+++ b/collective/MockMailHost/MockMailHost.py
@@ -43,7 +43,12 @@ class MockMailHost(MailHost.MailHost, SecureMailHost):
              charset=None,
              msg_type=None,
              ):
-        messageText = '\n'.join([x.strip() for x in messageText.split('\n')])
+
+        # messageText may be an MIMEText object, or something else.
+        # We onyl want to clean it up if it is a string.
+        if isinstance(messageText, (str, unicode)):
+            messageText = '\n'.join([x.strip() for x in messageText.split('\n')])
+
         self.msg_types.append(msg_type)
         super(MockMailHost, self).send(messageText, mto, mfrom,
                                        subject, encode, immediate, charset,

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix MIMEText compatibility (broken since 0.9).
+  [jone]
 
 
 0.9 (2015-07-10)


### PR DESCRIPTION
The messageText sent through the MailHost may be of type `MIMEText`, in which case we don't want it to be cleaned up.

See 7b55e3f17a36e333a1232b05bb96d57a785a7b31

/cc @sureshvv 
